### PR TITLE
fix: specify color scheme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,5 @@
- @import "tailwindcss";
+@import "tailwindcss";
+
+:root {
+  color-scheme: only dark;
+}


### PR DESCRIPTION
Dark reader extensions will flip the colors of a website, to force it to appear in dark mode, however if a website doesn't specify a color scheme, problems arise.

This PR fixes that, and specifies a [color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/color-scheme) which gives info to those extensions that this website is only available in dark mode.

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f8ad2733-6dad-4080-9b74-ba465f58b1f6" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c47d0286-b7e1-4194-9901-85bbbf4d5d32" />
